### PR TITLE
fix: correct column index offset in PSTTable7C.getItems()

### DIFF
--- a/src/PSTTable7C.class.ts
+++ b/src/PSTTable7C.class.ts
@@ -232,7 +232,7 @@ export class PSTTable7C extends PSTTable {
       item.isExternalValueReference = true
       currentItem.set(item.entryType.toNumber(), item)
 
-      let col = 0
+      let col = -1
       if (this.overrideCol > -1) {
         col = this.overrideCol - 1
       }


### PR DESCRIPTION
- Fix column iteration starting from index 1 instead of 0
- Change initial col value from 0 to -1 to ensure first element is processed
- Prevents skipping the first column descriptor in the table